### PR TITLE
指定出来ないホスト名を回避

### DIFF
--- a/03_appliance/02_load_balancer/load_balancer.tf
+++ b/03_appliance/02_load_balancer/load_balancer.tf
@@ -19,7 +19,7 @@ resource "sakuracloud_disk" "disks"{
     # パスワード
     password = "${var.password}"
     # ホスト名
-    hostname = "load_balancer_server${count.index}"
+    hostname = "load-balancer-server${count.index}"
 
     # SSH公開鍵を登録
     ssh_key_ids = ["${sakuracloud_ssh_key.key.id}"]


### PR DESCRIPTION
アンダースコアはホスト名に設定出来ないとdisk modifyで蹴られてしまうので、修正しました。